### PR TITLE
Bug 156

### DIFF
--- a/frontend/src/routes/projects/analytics/[prediction]/+page.svelte
+++ b/frontend/src/routes/projects/analytics/[prediction]/+page.svelte
@@ -67,9 +67,9 @@
 			} = {};
 			const metrics = await getMetricsResponse(dryRunId);
 			const result = await getMetricsUsageUtils(metrics);
-			cpuData = result.cpuData;
+			cpuData = result.cumulativeCpuData;
 			memoryData = result.memoryData;
-			networkDataCombined = result.networkDataCombined;
+			networkDataCombined = result.cumulativeNetworkData;
 			allStepNames = result.allStepNames;
 			const pipelineMetricsAnalytics: MetricsAnalytics = await getMetricsAnalyticsUtils(
 				allStepNames,

--- a/frontend/src/routes/projects/dryruns/[dry_run]/[resource]/+page.svelte
+++ b/frontend/src/routes/projects/dryruns/[dry_run]/[resource]/+page.svelte
@@ -266,58 +266,77 @@
 
 	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 	$: getResource = (resource: string) => {
-		let resourceData;
-		let wholeData: { x: string[]; y: number[]; type: string; name: string }[] = [];
+		const data: { x: string[]; y: number[]; type: string; name: string }[] = [];
 		switch (resource) {
 		case 'cpu-cumulative': {
-			resourceData = cumulativeCpuData;
-			if (Object.keys(cumulativeCpuData).length > 0)
-				allStepNames.forEach((step) => {
-					if (cumulativeCpuData[step]) wholeData.push(cumulativeCpuData[step]);
-				});
-		
+			if (Object.keys(cumulativeCpuData).length > 0) {
+				if (selectedStep === 'Total') {
+					allStepNames.forEach((step) => {
+						if (cumulativeCpuData[step]) data.push(cumulativeCpuData[step]);
+					});
+				} else {
+					data.push(cumulativeCpuData[selectedStep]);
+				}
+			}
 		break;
 		}
 		case 'cpu-current': {
-			resourceData = currentCpuData;
 			if (Object.keys(currentCpuData).length > 0)
-				allStepNames.forEach((step) => {
-					if (currentCpuData[step]) wholeData.push(currentCpuData[step]);
-				});
-		
+				if (selectedStep === 'Total') {
+					allStepNames.forEach((step) => {
+						if (currentCpuData[step]) data.push(currentCpuData[step]);
+					});
+				} else {
+					data.push(currentCpuData[selectedStep]);
+				}
 		break;
 		}
 		case 'memory': {
-			resourceData = memoryData;
 			if (Object.keys(memoryData).length > 0)
-				allStepNames.forEach((step) => {
-					if (memoryData[step]) wholeData.push(memoryData[step]);
-				});
-		
+				if (selectedStep === 'Total') {
+					allStepNames.forEach((step) => {
+						if (memoryData[step]) data.push(memoryData[step]);
+					});
+				} else {
+					data.push(memoryData[selectedStep]);
+				}
 		break;
 		}
+		case 'network-cumulative': {
+			if (Object.keys(cumulativeNetworkData).length > 0)
+				if (selectedStep === 'Total') {
+					allStepNames.forEach((step) => {
+						cumulativeNetworkData[step].forEach((networkData) => {
+							data.push(networkData);
+						});
+					});
+				} else {
+					cumulativeNetworkData[selectedStep].forEach((networkData) => {
+						data.push(networkData);
+					});
+				}
+		break;
+		}
+		case 'network-current': {
+			if (Object.keys(currentNetworkData).length > 0)
+				if (selectedStep === 'Total') {
+					allStepNames.forEach((step) => {
+						currentNetworkData[step].forEach((networkData) => {
+							data.push(networkData);
+						});
+					});
+				} else {
+					currentNetworkData[selectedStep].forEach((networkData) => {
+						data.push(networkData);
+					});
+				}
+		break;
+		}		
 		default: {
-			resourceData = currentNetworkData;
-			wholeData = [];
-			allStepNames.forEach((step) => {
-				currentNetworkData[step]?.forEach((elem) => {
-					wholeData.push(elem);
-				});
-			});
+			throw new Error('Invalid resource');
 		}
 		}
-		if (selectedStep !== 'Total') {
-			if (resource === 'network')
-				return {
-					title: `${selectedStep}`,
-					data: resourceData[selectedStep] ?? []
-				};
-			return {
-				title: `${selectedStep}`,
-				data: resourceData[selectedStep] ?? []
-			};
-		}
-		return { title: `- entire dry run`, data: wholeData };
+		return selectedStep === 'Total' ? { title: `- entire dry run`, data } : { title: `${selectedStep}`, data };
 	};
 
 	onMount(async () => {
@@ -512,8 +531,8 @@
 				</div>
 				<div class="card plotcard">
 					<Plot
-						data={getResource('network').data}
-						plotTitle={`Network ${getResource('network').title}`}
+						data={getResource('network-current').data}
+						plotTitle={`Network ${getResource('network-current').title}`}
 						xaxisTitle="time"
 						yaxisTitle="bytes"
 					/>

--- a/frontend/src/routes/projects/dryruns/[dry_run]/[resource]/+page.svelte
+++ b/frontend/src/routes/projects/dryruns/[dry_run]/[resource]/+page.svelte
@@ -268,75 +268,77 @@
 	$: getResource = (resource: string) => {
 		const data: { x: string[]; y: number[]; type: string; name: string }[] = [];
 		switch (resource) {
-		case 'cpu-cumulative': {
-			if (Object.keys(cumulativeCpuData).length > 0) {
-				if (selectedStep === 'Total') {
-					allStepNames.forEach((step) => {
-						if (cumulativeCpuData[step]) data.push(cumulativeCpuData[step]);
-					});
-				} else {
-					data.push(cumulativeCpuData[selectedStep]);
+			case 'cpu-cumulative': {
+				if (Object.keys(cumulativeCpuData).length > 0) {
+					if (selectedStep === 'Total') {
+						allStepNames.forEach((step) => {
+							if (cumulativeCpuData[step]) data.push(cumulativeCpuData[step]);
+						});
+					} else {
+						data.push(cumulativeCpuData[selectedStep]);
+					}
 				}
+				break;
 			}
-		break;
-		}
-		case 'cpu-current': {
-			if (Object.keys(currentCpuData).length > 0)
-				if (selectedStep === 'Total') {
-					allStepNames.forEach((step) => {
-						if (currentCpuData[step]) data.push(currentCpuData[step]);
-					});
-				} else {
-					data.push(currentCpuData[selectedStep]);
-				}
-		break;
-		}
-		case 'memory': {
-			if (Object.keys(memoryData).length > 0)
-				if (selectedStep === 'Total') {
-					allStepNames.forEach((step) => {
-						if (memoryData[step]) data.push(memoryData[step]);
-					});
-				} else {
-					data.push(memoryData[selectedStep]);
-				}
-		break;
-		}
-		case 'network-cumulative': {
-			if (Object.keys(cumulativeNetworkData).length > 0)
-				if (selectedStep === 'Total') {
-					allStepNames.forEach((step) => {
-						cumulativeNetworkData[step].forEach((networkData) => {
+			case 'cpu-current': {
+				if (Object.keys(currentCpuData).length > 0)
+					if (selectedStep === 'Total') {
+						allStepNames.forEach((step) => {
+							if (currentCpuData[step]) data.push(currentCpuData[step]);
+						});
+					} else {
+						data.push(currentCpuData[selectedStep]);
+					}
+				break;
+			}
+			case 'memory': {
+				if (Object.keys(memoryData).length > 0)
+					if (selectedStep === 'Total') {
+						allStepNames.forEach((step) => {
+							if (memoryData[step]) data.push(memoryData[step]);
+						});
+					} else {
+						data.push(memoryData[selectedStep]);
+					}
+				break;
+			}
+			case 'network-cumulative': {
+				if (Object.keys(cumulativeNetworkData).length > 0)
+					if (selectedStep === 'Total') {
+						allStepNames.forEach((step) => {
+							cumulativeNetworkData[step].forEach((networkData) => {
+								data.push(networkData);
+							});
+						});
+					} else {
+						cumulativeNetworkData[selectedStep].forEach((networkData) => {
 							data.push(networkData);
 						});
-					});
-				} else {
-					cumulativeNetworkData[selectedStep].forEach((networkData) => {
-						data.push(networkData);
-					});
-				}
-		break;
-		}
-		case 'network-current': {
-			if (Object.keys(currentNetworkData).length > 0)
-				if (selectedStep === 'Total') {
-					allStepNames.forEach((step) => {
-						currentNetworkData[step].forEach((networkData) => {
+					}
+				break;
+			}
+			case 'network-current': {
+				if (Object.keys(currentNetworkData).length > 0)
+					if (selectedStep === 'Total') {
+						allStepNames.forEach((step) => {
+							currentNetworkData[step].forEach((networkData) => {
+								data.push(networkData);
+							});
+						});
+					} else {
+						currentNetworkData[selectedStep].forEach((networkData) => {
 							data.push(networkData);
 						});
-					});
-				} else {
-					currentNetworkData[selectedStep].forEach((networkData) => {
-						data.push(networkData);
-					});
-				}
-		break;
-		}		
-		default: {
-			throw new Error('Invalid resource');
+					}
+				break;
+			}
+			default: {
+				throw new Error('Invalid resource');
+			}
 		}
-		}
-		return selectedStep === 'Total' ? { title: `- entire dry run`, data } : { title: `${selectedStep}`, data };
+		return selectedStep === 'Total'
+			? { title: `- entire dry run`, data }
+			: { title: `${selectedStep}`, data };
 	};
 
 	onMount(async () => {
@@ -440,18 +442,18 @@
 					<div class="card logcard row-span-4 p-5">
 						<!-- display if the dryrun has a non-empty phase message from argo (usually null if no error) -->
 						{#if dryRunPhaseMessage}
-						<div class="card logcard row-span-1 p-5">
-							<div style="display: flex; align-items: center; color: red; gap: 5px">
-								<AlertTriangleIcon />
-								<h1>Error Message</h1>
-							</div>
-							<section class="p-1">
-								<div class="w-full">
-									<CodeBlock language="json" code={dryRunPhaseMessage} />
+							<div class="card logcard row-span-1 p-5">
+								<div style="display: flex; align-items: center; color: red; gap: 5px">
+									<AlertTriangleIcon />
+									<h1>Error Message</h1>
 								</div>
-							</section>
-						</div>
-						{/if}				
+								<section class="p-1">
+									<div class="w-full">
+										<CodeBlock language="json" code={dryRunPhaseMessage} />
+									</div>
+								</section>
+							</div>
+						{/if}
 						<header class="card-header"><h1>Logs</h1></header>
 						<section class="p-1">
 							<br />

--- a/frontend/src/utils/resource-utils.ts
+++ b/frontend/src/utils/resource-utils.ts
@@ -122,15 +122,16 @@ function findMax(input: number[]): number {
 	return Math.max(...input);
 }
 
-function cumulativeToCurrent(inputData: {timestamp: number, value: number}[]): { timestamp: number; value: number }[] {
+function cumulativeToCurrent(
+	inputData: { timestamp: number; value: number }[]
+): { timestamp: number; value: number }[] {
 	let previousValue = 0;
 	const current: { timestamp: number; value: number }[] = [];
 	inputData.forEach((entry) => {
 		const updatedValue = entry.value - previousValue;
 		if (updatedValue) {
 			previousValue = entry.value;
-			current.push({timestamp: entry.timestamp, value: updatedValue});
-			
+			current.push({ timestamp: entry.timestamp, value: updatedValue });
 		}
 	});
 	return current;
@@ -162,7 +163,7 @@ export async function getMetricsUsageUtils(metrics: DryRunMetrics[]): Promise<{
 	} = {};
 	const currentNetworkData: {
 		[key: string]: MetricsWithTimeStamps[];
-	} = {};	
+	} = {};
 	const logs: { [x: string]: string } = {};
 	metrics
 		?.filter((metric) => metric.type === 'Pod')
@@ -173,7 +174,9 @@ export async function getMetricsUsageUtils(metrics: DryRunMetrics[]): Promise<{
 					logs[node.displayName] = node.log.join('\n');
 				}
 				// HOTFIX (a.k.a. hack) to display absolute CPU usage instead of cumulative usage in seconds
-				const cpuCurrent: { timestamp: number; value: number }[] = cumulativeToCurrent(node.metrics.cpuUsageSecondsTotal);
+				const cpuCurrent: { timestamp: number; value: number }[] = cumulativeToCurrent(
+					node.metrics.cpuUsageSecondsTotal
+				);
 
 				currentCpuData[node.displayName] = changeResourceFormat(
 					node.startedAt,
@@ -206,7 +209,7 @@ export async function getMetricsUsageUtils(metrics: DryRunMetrics[]): Promise<{
 						node.displayName,
 						'network-transmitted-cumulative'
 					)
-				)
+				);
 				if (!currentNetworkData[node.displayName]) currentNetworkData[node.displayName] = [];
 				currentNetworkData[node.displayName].push(
 					changeResourceFormat(
@@ -221,11 +224,19 @@ export async function getMetricsUsageUtils(metrics: DryRunMetrics[]): Promise<{
 						node.displayName,
 						'network-transmitted-current'
 					)
-				);		
+				);
 			}
 		});
 
-	return { allStepNames, cumulativeCpuData, currentCpuData, memoryData, cumulativeNetworkData, currentNetworkData, logs };
+	return {
+		allStepNames,
+		cumulativeCpuData,
+		currentCpuData,
+		memoryData,
+		cumulativeNetworkData,
+		currentNetworkData,
+		logs
+	};
 }
 
 export async function getMetricsAnalyticsUtils(

--- a/frontend/src/utils/resource-utils.ts
+++ b/frontend/src/utils/resource-utils.ts
@@ -122,6 +122,20 @@ function findMax(input: number[]): number {
 	return Math.max(...input);
 }
 
+function cumulativeToCurrent(inputData: {timestamp: number, value: number}[]): { timestamp: number; value: number }[] {
+	let previousValue = 0;
+	const current: { timestamp: number; value: number }[] = [];
+	inputData.forEach((entry) => {
+		const updatedValue = entry.value - previousValue;
+		if (updatedValue) {
+			previousValue = entry.value;
+			current.push({timestamp: entry.timestamp, value: updatedValue});
+			
+		}
+	});
+	return current;
+}
+
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const calculateDuration = (metrics: DryRunMetrics[]) => {
 	const duration =
@@ -132,17 +146,23 @@ export const calculateDuration = (metrics: DryRunMetrics[]) => {
 
 export async function getMetricsUsageUtils(metrics: DryRunMetrics[]): Promise<{
 	allStepNames: string[];
-	cpuData: any;
+	cumulativeCpuData: any;
+	currentCpuData: any;
 	memoryData: any;
-	networkDataCombined: any;
+	cumulativeNetworkData: any;
+	currentNetworkData: any;
 	logs: { [x: string]: string };
 }> {
 	const allStepNames: string[] = [];
-	const cpuData: { [key: string]: MetricsWithTimeStamps } = {};
+	const cumulativeCpuData: { [key: string]: MetricsWithTimeStamps } = {};
+	const currentCpuData: { [key: string]: MetricsWithTimeStamps } = {};
 	const memoryData: { [key: string]: MetricsWithTimeStamps } = {};
-	const networkDataCombined: {
+	const cumulativeNetworkData: {
 		[key: string]: MetricsWithTimeStamps[];
 	} = {};
+	const currentNetworkData: {
+		[key: string]: MetricsWithTimeStamps[];
+	} = {};	
 	const logs: { [x: string]: string } = {};
 	metrics
 		?.filter((metric) => metric.type === 'Pod')
@@ -152,77 +172,101 @@ export async function getMetricsUsageUtils(metrics: DryRunMetrics[]): Promise<{
 				if (node.log) {
 					logs[node.displayName] = node.log.join('\n');
 				}
-				cpuData[node.displayName] = changeResourceFormat(
+				// HOTFIX (a.k.a. hack) to display absolute CPU usage instead of cumulative usage in seconds
+				const cpuCurrent: { timestamp: number; value: number }[] = cumulativeToCurrent(node.metrics.cpuUsageSecondsTotal);
+
+				currentCpuData[node.displayName] = changeResourceFormat(
+					node.startedAt,
+					cpuCurrent,
+					node.displayName,
+					'cpu-current'
+				);
+				cumulativeCpuData[node.displayName] = changeResourceFormat(
 					node.startedAt,
 					node.metrics.cpuUsageSecondsTotal,
 					node.displayName,
-					'cpu'
+					'cpu-cumulative'
 				);
 				memoryData[node.displayName] = changeResourceFormat(
 					node.startedAt,
 					node.metrics.memoryUsageBytes,
 					node.displayName
 				);
-				if (!networkDataCombined[node.displayName]) networkDataCombined[node.displayName] = [];
-				networkDataCombined[node.displayName].push(
+				if (!cumulativeNetworkData[node.displayName]) cumulativeNetworkData[node.displayName] = [];
+				cumulativeNetworkData[node.displayName].push(
 					changeResourceFormat(
 						node.startedAt,
 						node.metrics.networkReceiveBytesTotal,
 						node.displayName,
-						'Received'
+						'network-received-cumulative'
 					),
 					changeResourceFormat(
 						node.startedAt,
 						node.metrics.networkTransmitBytesTotal,
 						node.displayName,
-						'Transmitted'
+						'network-transmitted-cumulative'
 					)
-				);
+				)
+				if (!currentNetworkData[node.displayName]) currentNetworkData[node.displayName] = [];
+				currentNetworkData[node.displayName].push(
+					changeResourceFormat(
+						node.startedAt,
+						cumulativeToCurrent(node.metrics.networkReceiveBytesTotal),
+						node.displayName,
+						'network-received-current'
+					),
+					changeResourceFormat(
+						node.startedAt,
+						cumulativeToCurrent(node.metrics.networkTransmitBytesTotal),
+						node.displayName,
+						'network-transmitted-current'
+					)
+				);		
 			}
 		});
 
-	return { allStepNames, cpuData, memoryData, networkDataCombined, logs };
+	return { allStepNames, cumulativeCpuData, currentCpuData, memoryData, cumulativeNetworkData, currentNetworkData, logs };
 }
 
 export async function getMetricsAnalyticsUtils(
 	allStepNames: string[],
 	metrics: DryRunMetrics[],
-	cpuData: { [x: string]: { x: string[]; y: number[]; type: string; name: string } },
+	cumulativeCpuData: { [x: string]: { x: string[]; y: number[]; type: string; name: string } },
 	memoryData: { [x: string]: { x: string[]; y: number[]; type: string; name: string } },
-	networkDataCombined: { [x: string]: { x: string[]; y: number[]; type: string; name: string }[] }
+	cumulativeNetworkData: { [x: string]: { x: string[]; y: number[]; type: string; name: string }[] }
 ): Promise<MetricsAnalytics> {
 	const pipelineMetricsAnalytics: MetricsAnalytics = {};
 
 	allStepNames.forEach((name) => {
 		pipelineMetricsAnalytics[name] = initMaxResourcePerStep();
-		pipelineMetricsAnalytics[name].CPU.max = findMax(cpuData[name].y);
-		pipelineMetricsAnalytics[name].CPU.avg = calculateMean(cpuData[name].y);
+		pipelineMetricsAnalytics[name].CPU.max = findMax(cumulativeCpuData[name].y);
+		pipelineMetricsAnalytics[name].CPU.avg = calculateMean(cumulativeCpuData[name].y);
 		pipelineMetricsAnalytics[name].Memory.max = findMax(memoryData[name].y);
 		pipelineMetricsAnalytics[name].Memory.avg = calculateMean(memoryData[name].y);
-		pipelineMetricsAnalytics[name].Network_received.max = findMax(networkDataCombined[name][0].y);
+		pipelineMetricsAnalytics[name].Network_received.max = findMax(cumulativeNetworkData[name][0].y);
 		pipelineMetricsAnalytics[name].Network_received.avg = calculateMean(
-			networkDataCombined[name][0].y
+			cumulativeNetworkData[name][0].y
 		);
 		pipelineMetricsAnalytics[name].Network_transferred.max = findMax(
-			networkDataCombined[name][1].y
+			cumulativeNetworkData[name][1].y
 		);
 		pipelineMetricsAnalytics[name].Network_transferred.avg = calculateMean(
-			networkDataCombined[name][1].y
+			cumulativeNetworkData[name][1].y
 		);
 	});
 
 	// calculate for total dry run
 	pipelineMetricsAnalytics.Total = initMaxResourcePerStep();
-	let allValues = allStepNames.flatMap((name) => cpuData[name].y);
+	let allValues = allStepNames.flatMap((name) => cumulativeCpuData[name].y);
 	pipelineMetricsAnalytics.Total.CPU.max = findMax(allValues);
 	pipelineMetricsAnalytics.Total.CPU.avg += calculateMean(allValues);
 	allValues = allStepNames.flatMap((name) => memoryData[name].y);
 	pipelineMetricsAnalytics.Total.Memory.max = findMax(allValues);
 	pipelineMetricsAnalytics.Total.Memory.avg += calculateMean(allValues);
-	allValues = allStepNames.flatMap((name) => networkDataCombined[name][0].y);
+	allValues = allStepNames.flatMap((name) => cumulativeNetworkData[name][0].y);
 	pipelineMetricsAnalytics.Total.Network_received.max = findMax(allValues);
 	pipelineMetricsAnalytics.Total.Network_received.avg += calculateMean(allValues);
-	allValues = allStepNames.flatMap((name) => networkDataCombined[name][1].y);
+	allValues = allStepNames.flatMap((name) => cumulativeNetworkData[name][1].y);
 	pipelineMetricsAnalytics.Total.Network_transferred.max = findMax(allValues);
 	pipelineMetricsAnalytics.Total.Network_transferred.avg += calculateMean(allValues);
 	metrics


### PR DESCRIPTION
Resolves #156 

What has been done:

- resource-utils.ts - new function for computing current value from cumulative value. The function getMetricsUsageUtils has been updated to return additional metrics for current CPU data and current Network transmitted and received data. 
- SIM-PIPE/frontend/src/routes/projects/dryruns/[dry_run]/[resource]/+page.svelte has been been updated to receive this new data from getMetricsUsageUtils.
- The very same frontend page as mention above has got an update of its getResource function. This function extracts the relevant data for the plotting function depending on what data is queried for the plot.
- Minor beauty-fix for how error message from pipeline is displayed in the logcard at the top of the log entries, and max-height of the logbox to prevent plots from being rendered very large in the y-direction of the page.