### PR TITLE
Imageref hotfix

### DIFF
--- a/frontend/src/routes/secrets/[secret_id]/+page.svelte
+++ b/frontend/src/routes/secrets/[secret_id]/+page.svelte
@@ -98,7 +98,23 @@
 			imageRefFullName += `:${tag}`;
 		}
 		return imageRefFullName;
-	}	
+	}
+
+	/*
+	TODO: check theses cases:
+
+	let img1 = 'registry.com:5000/namespace/image:tag';
+let img2 = '/namespace/image';
+let img3 = 'organization/myimage:reftag';
+let img4 = 'image:tag';
+let img5 = 'image';
+
+console.log(getNewImageFullName(components = extractImageStringComponents(img1), finalRegistryUrl = 'yolo.com', finalPort = '999'));
+console.log(getNewImageFullName(components = extractImageStringComponents(img2), finalRegistryUrl = 'yolo.com', finalPort = '999'));
+console.log(getNewImageFullName(components = extractImageStringComponents(img3), finalRegistryUrl = 'yolo.com', finalPort = '999'));
+console.log(getNewImageFullName(components = extractImageStringComponents(img4), finalRegistryUrl = 'yolo.com', finalPort = '999'));
+console.log(getNewImageFullName(components = extractImageStringComponents(img5), finalRegistryUrl = 'yolo.com', finalPort = '999'));
+*/
 
 	async function onSubmitForm(): Promise<void> {
 		console.log('submitting form');


### PR DESCRIPTION
Support updating image reference when attaching a new image registry to a project.

When adding an image registry to a project we would like to add the registry url at the beginning of the image reference. However, image references can be written in several ways:
- 'https://registry.com/namespace/image:tag';
- 'registry.com:5000/namespace/image:tag';
- '/namespace/image';
- 'organization/myimage:reftag';
- 'image:tag';
- 'image';
- 'registry.com/namespace/image';


When adding a image registry to a project, the registry is defined by an url, and we would like to update the url of the image registry in the image reference, simply:

`registryUrl/imagePath`

We have to identify the `registryUrl` and the `imagePath`, in order to acheive this. This is what has been done in this imageref hotfix in order to correctly update the image reference correctly.