### PR TITLE
fix: conrollerUrl == graphqlUrl running on port 8087

### DIFF
--- a/frontend/src/utils/keycloak.client.ts
+++ b/frontend/src/utils/keycloak.client.ts
@@ -25,7 +25,7 @@ function parseSimPipeEnvironment(): {
 				// eslint-disable-next-line unicorn/prefer-ternary
 				if (port === ':8088') {
 					console.log('localhost:', localhostMatch[1], 'port:', port);
-					graphqlUrl = 'http://localhost:8086/graphql';
+					graphqlUrl = 'http://localhost:8087/graphql';
 				} else if (port === ':5173') {
 					console.log('localhost:', localhostMatch[1], 'port:', port);
 					graphqlUrl = 'http://localhost:9000/graphql';


### PR DESCRIPTION
Conroller == graphql api, is running on port 8087. Not 8086 ref. list of service endpoints below.

list of services endpoints: 

sftpgo: http://localhost:8083
argo: http://localhost:8084
minio: http://localhost:8085
prometheus: http://localhost:8086
controller: http://localhost:8087
frontend: http://localhost:8088