### PR TITLE
fix: use simpipe version 0.4.7

### DIFF
--- a/charts/simpipe/Chart.yaml
+++ b/charts/simpipe/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: simpipe
 description: SIMPIPE on Kubernetes
 type: application
-version: 0.4.6
-appVersion: 0.4.6
+version: 0.4.7
+appVersion: 0.4.7
 dependencies:
   - name: cadvisor
     #version: "2.3.0"


### PR DESCRIPTION
use latest version (0.4.7) of simpipe. 
There is a bug in version 0.4.6 that in the frontend uses prometheus' port in stead of the controller port, when trying to contact the controller. 