### PR TITLE
fix(bug): 🐛 resolves #181

### DIFF
--- a/frontend/src/queries/get_all_artifacts.ts
+++ b/frontend/src/queries/get_all_artifacts.ts
@@ -5,7 +5,6 @@ const allArtifactsQuery = gql`
 		artifacts(bucketName: $bucketName) {
 			name
 			url
-			size
 			bucketName
 		}
 	}


### PR DESCRIPTION
This bugfix avoids the problem by not querying the backend for the file size.